### PR TITLE
修正判断字符串是否为数值的逻辑

### DIFF
--- a/nlm_ingestor/ingestor/line_parser.py
+++ b/nlm_ingestor/ingestor/line_parser.py
@@ -6,6 +6,8 @@ import string
 
 from nltk.corpus import stopwords
 
+from nlm_ingestor.ingestor_utils.utils import is_arabic_number
+
 from .patterns import abbreviations
 from .patterns import states
 from .patterns import states_abbreviations
@@ -177,7 +179,7 @@ class Word:
         word = self.text.lower()
         if not word.isalpha():
             if word.isprintable():
-                if not word.isnumeric():
+                if not is_arabic_number(word):
                     if word.startswith("(") and word.endswith(")"):
                         word = word[1:-1]
                     if word.startswith("-"):
@@ -199,13 +201,12 @@ class Word:
                     if word.startswith("(") and word.endswith(")"):
                         word = word[1:-1]
                     word = word.replace(",", "")
-                    if word.isnumeric() or word.replace(".", "", 1).isnumeric():
-                        self.is_number = True
+                    self.is_number = is_arabic_number(word)
                     parts = word.split("-")
                     if (
                         len(parts) == 2
-                        and parts[0].isnumeric()
-                        and parts[1].isnumeric()
+                        and is_arabic_number(parts[0])
+                        and is_arabic_number(parts[1])
                     ):
                         self.is_number_range = True
                         self.parts = parts

--- a/nlm_ingestor/ingestor/styling_utils.py
+++ b/nlm_ingestor/ingestor/styling_utils.py
@@ -6,6 +6,7 @@ from statistics import median
 
 from nlm_ingestor.ingestor import formatter
 from nlm_ingestor.ingestor import line_parser
+from nlm_ingestor.ingestor_utils.utils import is_arabic_number
 from nlm_ingestor.ingestor_utils.word_splitter import WordSplitter
 
 ws = WordSplitter()
@@ -52,7 +53,7 @@ HELPER FUNCTIONS
 
 
 def font_weight_is_float(s):
-    return s.split(".")[0].isnumeric()
+    return is_arabic_number(s.split(".")[0])
 
 
 def get_p_styling_dict(style_str: str) -> dict:
@@ -169,7 +170,7 @@ def mode_of_list(fonts: list):
 def no_style_p_to_lines(p_item):
     lines = []
     p_text = unicodedata.normalize("NFKD", p_item.text)
-    if len(p_text) > 0 and not p_text.strip().isnumeric():
+    if len(p_text) > 0 and not is_arabic_number(p_text.strip()):
         text_lines = p_text.split("\n")
         for text in text_lines:
             line = ""

--- a/nlm_ingestor/ingestor_utils/utils.py
+++ b/nlm_ingestor/ingestor_utils/utils.py
@@ -307,3 +307,13 @@ def get_block_texts(blocks):
             block_texts.append(block["block_text"])
             block_info.append(block)
     return block_texts, block_info
+
+
+ARABIC_NUMBER_PATTERN = re.compile(r"^\d+(\.\d+)?$")
+
+
+def is_arabic_number(text: str):
+    """
+    Check if the text is an arabic number.
+    """
+    return bool(ARABIC_NUMBER_PATTERN.match(text))


### PR DESCRIPTION
## 更新内容

- 修正判断字符串是否为数字的逻辑
  - 更新前：使用 `isnumeric()` 判断是否为数字并转为 float，导致 `1万`、`4²` 等被视为数值并在转换时打印了错误日志
    <img width="187" alt="screenshot-2024-04-08 16 11 58" src="https://github.com/hongshancapital/nlm-ingestor/assets/118239674/ddec18fd-5e4b-40b1-acab-0d04d13fbebf">
  - 更新后：使用正则表达式 `^\d+(\.\d+)?$` 判断

## 测试

### 修正前：会尝试将非阿拉伯数字字符串转为 float 导致输出错误日志

> 代码中 catch 了错误，并 fallback 到不是数字的 case

<img width="233" alt="screenshot-2024-04-08 17 42 04" src="https://github.com/hongshancapital/nlm-ingestor/assets/118239674/a8181591-af56-4953-8289-376046072804">

<img width="1350" alt="screenshot-2024-04-08 17 42 13" src="https://github.com/hongshancapital/nlm-ingestor/assets/118239674/15461931-80f1-4a7f-a725-d376fd4ac5fe">

### 修正后：不会尝试将非阿拉伯数字字符串转为 float

<img width="455" alt="screenshot-2024-04-08 17 39 10" src="https://github.com/hongshancapital/nlm-ingestor/assets/118239674/890f2d42-141f-43c1-be14-09073cef86fa">

<img width="1350" alt="screenshot-2024-04-08 17 39 53" src="https://github.com/hongshancapital/nlm-ingestor/assets/118239674/dc4c1010-2293-4ee0-bf8e-758d0d02299e">

### 修正前后输出结果比较：相同

![screenshot-2024-04-08 17 46 54](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/407665f6-ea30-49bf-b5ef-1b369bea1bd7)
