### PR TITLE
使用 html5lib 解析 HTML

### DIFF
--- a/nlm_ingestor/ingestor/html_ingestor.py
+++ b/nlm_ingestor/ingestor/html_ingestor.py
@@ -17,7 +17,7 @@ class HTMLIngestor:
             self.html = file_name
         else:
             f = codecs.open(file_name, 'r')
-            self.html = BeautifulSoup(f.read(), features="lxml")
+            self.html = BeautifulSoup(f.read(), features="html5lib")
             self.html = self.html.find("body")
         self.sec = sec
         self.blocks = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ lxml==4.9.1
 unidecode
 nlm-utils
 boto3==1.34.79
+html5lib==1.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
         "lxml==4.9.1",
         "unidecode",
         "nlm-utils",
-        "boto3==1.34.79"
+        "boto3==1.34.79",
+        "html5lib==1.1"
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
## 问题背景

- 更新前 NLM Ingestor 使用 lxml 解析 HTML，如果 HTML 不规范可能会导致无法正确解析 HTML
  > 例如， [这个网站](https://www.gov.cn/zhengce/zhengceku/2023-04/26/content_5753299.htm) 的静态 HTML 中 `<body>...</body>` 内错误地包含了一个 `</html>`，导致 body 部分的内容被截断（因为 XML 是严格的，而用 lxml 解析 HTML 不会对不规范的部分容错）
    ![screenshot-2024-04-26 13 47 26](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/5807a527-0123-4f21-bd70-fff9748ac4ec)

## 解决办法

- 改为使用 html5lib 解析 HTML
  ![screenshot-2024-04-26 14 09 39](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/241bfc0a-6834-4f35-a8bb-9ede7e54ac55)

## 测试

### 更新前：由于 HTML 不规范导致 body 部分内容被截断

![screenshot-2024-04-26 13 34 16](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/085844d7-c7f3-47b5-8d38-5c94a76954c5)

![screenshot-2024-04-26 14 39 16](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/7120f763-a3eb-4504-a3df-e1be812a1851)

### 更新后：能够修正不规范的 HTML

![screenshot-2024-04-26 13 39 46](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/3e62bf20-8f17-49ae-a628-fdfb7210b825)

![screenshot-2024-04-26 14 37 59](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/089bda87-3bee-4b45-ad60-a9269a68c557)
