### PR TITLE
[优化] Detect file original encoding

### DIFF
--- a/nlm_ingestor/ingestor/html_ingestor.py
+++ b/nlm_ingestor/ingestor/html_ingestor.py
@@ -1,6 +1,6 @@
 import logging
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, UnicodeDammit
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
 from nlm_ingestor.ingestor_utils.utils import sent_tokenize
@@ -16,7 +16,10 @@ class HTMLIngestor:
         if str(type(file_name)) == "<class 'bs4.element.Tag'>":
             self.html = file_name
         else:
-            f = codecs.open(file_name, 'r')
+            with open(file_name, 'rb') as f:
+                raw_data = f.read()
+                suggestion = UnicodeDammit(raw_data)
+            f = codecs.open(file_name, 'r', encoding=suggestion.original_encoding, errors='ignore')
             self.html = BeautifulSoup(f.read(), features="html5lib")
             self.html = self.html.find("body")
         self.sec = sec


### PR DESCRIPTION
## 更新内容

- 问题：NLM Ingestor 解析 HTML 时使用默认的 UTF-8 解码，导致解析非 UTF-8 编码的文件时报错
- 解决办法：
  - 尝试通过 BeautifulSoup 的 UnicodeDammit 取得文件的原始编码
  - 并在解码文件时忽略解码错误

## 测试

### 更新前：解析非 UTF-8 编码的文件时报错

![1](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/53fec541-c9d5-4de0-b2da-68eb1e46f0b3)

### 更新后：可以正确解析 UTF-8 编码和非 UTF-8 编码的文件

![2 1](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/6cb30d25-02a3-4b61-967b-c4615c601264)

![2 2](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/41188a4e-d9a6-400d-a58b-cd5748316811)

![2 3](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/92c463ce-9f17-4042-bd47-4391e6333f8d)

![2 4](https://github.com/hongshancapital/nlm-ingestor/assets/118239674/6c1f5b35-ed78-4bbb-b015-a5c08b104644)
