### PR TITLE
修复 NoneType object is not subscriptable 错误

### DIFF
--- a/nlm_ingestor/ingestor/visual_ingestor/new_indent_parser.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/new_indent_parser.py
@@ -239,7 +239,7 @@ class NewIndentParser(object):
             if curr_header and block['block_type'] in ['para', 'table', 'list', 'table_row']:
                 block['level'] = curr_header['level'] + 1
             if block['block_type'] in ['list_item']:
-                if prev_block and prev_block['block_type'] in ['para', 'list_item'] and \
+                if curr_header and prev_block and prev_block['block_type'] in ['para', 'list_item'] and \
                         prev_block['block_text'].endswith(':'):
                     block['level'] = curr_header['level'] + 1
                 elif prev_block and prev_block['block_type'] in ['list_item']:


### PR DESCRIPTION
## Description

- 问题现象：解析 PDF 时抛出 `'NoneType' object is not subscriptable` 异常
  <img width="1035" alt="screenshot-2024-08-01 11 47 17" src="https://github.com/user-attachments/assets/7ece6853-c57e-4620-a29b-719baa16c219">
- 问题原因
  ![screenshot-2024-08-01 11 40 43](https://github.com/user-attachments/assets/048ae7ee-5996-42f9-9509-586a88e2b593)
  - NLM Ingestor 会将前一个元素是段落（para）或列表项目（list_item）、且内容以半角冒号 `:` 结尾的列表项目的缩进级别设置为当前 Header 的缩进级别 + 1
  - 根据修正前的实现逻辑，如果同时满足以下条件，将会抛错
    - 当前列表项目前没有任何 Header
    - 当前列表项目前一个元素为段落或列表项目
    - 当前列表项目前的元素的内容以半角冒号结尾
- 解决办法：使用 curr_header 前判断是否不为 None

## Test

### 测试文件

- 会报错的文件：[error.pdf](https://github.com/user-attachments/files/16449985/error.pdf)
- 有 Header 而不会报错的文件：[normal1.pdf](https://github.com/user-attachments/files/16449987/normal1.pdf)
- 前一个元素不以 `:` 结尾而不会报错的文件：[normal2.pdf](https://github.com/user-attachments/files/16449988/normal2.pdf)

### 更新前

![screenshot-2024-08-01 11 28 58](https://github.com/user-attachments/assets/e9e95fab-08e8-4d6c-b8c5-61d9b98acef3)

![screenshot-2024-08-01 11 29 57](https://github.com/user-attachments/assets/ca177f98-6ce9-4af4-b0b3-3fe77ff4020e)

![screenshot-2024-08-01 11 31 04](https://github.com/user-attachments/assets/3c580ed4-9db0-413c-aaa4-c7d022be1485)

### 更新后

![screenshot-2024-08-01 11 35 24](https://github.com/user-attachments/assets/394d87c2-efbd-4122-9c9a-0945561fe55b)
