### PR TITLE
修复 NLM Ingestor Bug

### DIFF
--- a/nlm_ingestor/ingestor/visual_ingestor/indent_parser.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/indent_parser.py
@@ -292,7 +292,7 @@ class IndentParser:
                             if l["list_type"] == new_class["list_type"]:
                                 if l_idx > prev_level:
                                     new_stack.append(new_class)
-                                elif l_idx == prev_level:
+                                elif l_idx == prev_level and new_stack:
                                     # Replace with the new class
                                     new_stack.pop()
                                     new_stack.append(new_class)
@@ -538,7 +538,7 @@ class IndentParser:
                                           left_aligned_same_class_list_header):
                             level = len(new_stack)
                             new_class_added = False
-                            if smaller_font_left_aligned or left_aligned_same_class_list_header:
+                            if (smaller_font_left_aligned or left_aligned_same_class_list_header) and new_stack:
                                 # Remove from the stack and replace it with the new class below.
                                 new_stack.pop()
                             if not larger_font_left_aligned or \
@@ -607,7 +607,7 @@ class IndentParser:
 
                                 block["parent_list_idx"] = block["block_idx"] - 1
                             return level, new_stack, indent_reason
-                        else:
+                        elif new_stack:
                             # new_stack.append(level_class_name)
                             new_stack.pop()
                     if not new_stack:

--- a/nlm_ingestor/ingestor/visual_ingestor/style_utils.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/style_utils.py
@@ -1,5 +1,8 @@
+import re
+
 from nlm_ingestor.ingestor_utils.ing_named_tuples import BoxStyle, LineStyle
 
+word_font_pattern = re.compile(r"^(.+?),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)$")
 font_weights = {"normal": 400, "bold": 600, "bolder": 900, "lighter": 200}
 font_families = {"bold": 600, "light": 200}
 font_scale = 1.2
@@ -66,7 +69,7 @@ def parse_tika_style(style_str: str, text_str: str, page_width: float) -> dict:
         if "," in font_family and font_family in wf:
             new_font_family = font_family.replace(",", "-")
             wf = wf.replace(font_family, new_font_family)
-        wf_parts = wf.split(",")
+        wf_parts = word_font_pattern.match(wf).groups()
         wf_font_space_width = round(float(wf_parts[5]), 2)
         word_line_styles.append(
             LineStyle(


### PR DESCRIPTION
## 描述

修复以下问题

- `pop from empty list` 异常
  - 原因：计算 PDF 元素层级时，new_stack 可能已经通过 pop() 操作变成空 List，此时继续 pop() 将发生异常
  - 解决办法：pop() 前确认 new_stack 不为空
- `could not convert string to float: 'normal'` 异常
  - 原因（推测）：
    ![screenshot-2024-08-05 17 55 11](https://github.com/user-attachments/assets/2f36b72f-062a-47f7-8159-f6f6c8282f82)
    - 计算缩进的函数中会解析字体信息，字体信息格式为 `字体名,字重,样式,字体大小,字体大小,字间距`，如 `Arial,400,normal,12.0,12.0,6.0`
    - 如果字体名中包含 `,`，且字体信息中包含字体名，NLM Ingestor 会尝试将 `,` 替换为 `-` 后再继续处理
    - 但是如果之前取得的字体名与字体信息中的字体名不一致，将不会替换，导致后续处理出错
    - 例如
      - 之前取得的字体名是 `ArialBlack`
      - 字体信息为 `Arial,Black,400,normal,12.0,12.0,6.0`
      那么后续处理将会把 `normal` 作为字体大小，从而在转为 float 时报错
  - 解决办法：
    - 更新前，通过 `,` 分割字体信息，如果字体名部分包含 `,` 将可能导致取得的字体大小不正确
    - 更新后，通过正则表达式 `^(.+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)$` 分割字体信息

## 测试

### 修复 pop from empty list 异常

- 更新前
  ![screenshot-2024-08-05 15 52 32](https://github.com/user-attachments/assets/0c8e79a7-7049-4bf9-b753-5963edb4609b)
- 更新后
  ![screenshot-2024-08-05 15 54 57](https://github.com/user-attachments/assets/be5e7de2-559f-4c13-af7f-21470db891bb)

### 修复 could not convert string to float 异常

⚠️ 没有找到文件名带有 `,` 的字体，通过修改代码模拟 Bug 场景测试

- 更新前
  ![screenshot-2024-08-05 17 29 58](https://github.com/user-attachments/assets/b8c0ffb2-8e2f-4ed6-9e38-a48191713321)
- 更新后
  ![screenshot-2024-08-05 17 31 35](https://github.com/user-attachments/assets/2b35e0f3-f377-4485-932f-6bc5122856d3)
