### PR TITLE
修复整数转换错误

### DIFF
--- a/nlm_ingestor/ingestor/html_ingestor.py
+++ b/nlm_ingestor/ingestor/html_ingestor.py
@@ -3,7 +3,7 @@ import logging
 from bs4 import BeautifulSoup, UnicodeDammit
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
-from nlm_ingestor.ingestor_utils.utils import sent_tokenize
+from nlm_ingestor.ingestor_utils.utils import sent_tokenize, is_integer
 from nlm_ingestor.ingestor import line_parser
 import codecs
 
@@ -209,7 +209,7 @@ class HTMLIngestor:
                             all_th = False
                         if col.get("colspan"):
                             header_group_flag = True
-                        col_spans.append(int(col.get("colspan")) if col.get("colspan") else 1)
+                        col_spans.append(int(col.get("colspan")) if is_integer(col.get("colspan")) else 1)
                     empty_cols.append(empty_col)
 
                     if not ''.join(col_text).strip():

--- a/nlm_ingestor/ingestor/sec_html_ingestor.py
+++ b/nlm_ingestor/ingestor/sec_html_ingestor.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
-from nlm_ingestor.ingestor_utils.utils import sent_tokenize
+from nlm_ingestor.ingestor_utils.utils import sent_tokenize, is_integer
 from nlm_ingestor.ingestor import line_parser
 import codecs
 
@@ -170,7 +170,7 @@ class SECDoc:
                             all_th = False
                         if col.get("colspan"):
                             header_group_flag = True
-                        col_spans.append(int(col.get("colspan")) if col.get("colspan") else 1)
+                        col_spans.append(int(col.get("colspan")) if is_integer(col.get("colspan")) else 1)
 
                     table_row = {
                         "block_idx": len(self.blocks),

--- a/nlm_ingestor/ingestor_utils/utils.py
+++ b/nlm_ingestor/ingestor_utils/utils.py
@@ -545,3 +545,10 @@ def normalize_kangxi_radicals(text: str) -> str:
     for kangxi_radical, chinese_character in KANGXI_RADICAL_CHINESE_CHARACTER_MAPPING:
         text = text.replace(kangxi_radical, chinese_character)
     return text
+
+
+def is_integer(text: str | None) -> bool:
+    """
+    Check if all the characters in the text are integers.
+    """
+    return bool(re.fullmatch(r'\d+', text or ''))


### PR DESCRIPTION
## Description

- 问题发生场景
  - HTML 中存在有 colspan 属性的 td/th 元素，但 colspan 的值不为有效的整数
  - NLM Ingestor 尝试将 colspan 属性值转为整数，但只判断是否有值而没有判断值的有效性
- 解决办法
  - 将 colspan 转为整数前判断 colspan 的值是否有效

## Test

### 测试 HTML 的内容

```html
<!DOCTYPE html>
<html>
<head>
<meta charset="UTF-8" />
<title>Demo</title>
</head>
<body>
<table>
  <tr>
    <th rowspan="2;">A</th>
    <th colspan="4;">B</th> <!-- 本次发生问题的原因 -->
  </tr>
  <tr>
    <th>B1</th>
    <th>B2</th>
    <th colspan="²">B3</th> <!-- "²".isdigit() 会通过检查，所以使用正则表达式判断 -->
  </tr>
  <tr>
    <td>R1:C1</td>
    <td>R1:C2</td>
    <td>R1:C3</td>
    <td>R1:C4</td>
    <td>R1:C5</td>
  </tr>
  <tr>
    <td>R2:C1</td>
    <td>R2:C2</td>
    <td>R2:C3</td>
    <td>R2:C4</td>
    <td>R2:C5</td>
  </tr>
</table>
</body>
</html>
```

### 更新前：colspan 无效，转换为整数失败，报错

![screenshot-2024-08-19 15 57 48](https://github.com/user-attachments/assets/00f2fde1-bbcd-4659-93b5-27c1ad6ac0fc)

### 更新后：忽略无效的 colspan，不报错

![screenshot-2024-08-19 16 25 49](https://github.com/user-attachments/assets/205fe154-bf4f-4fb4-bf78-2f941ebaf0f9)
