### PR TITLE
get_list_item_sum 空字符串 fallback 到 0

### DIFF
--- a/nlm_ingestor/ingestion_daemon/config.py
+++ b/nlm_ingestor/ingestion_daemon/config.py
@@ -3,6 +3,8 @@ from distutils import util as dutils
 from typing import List
 from typing import Optional
 
+from nlm_ingestor.ingestor_utils.utils import safe_int
+
 __CFG = dict()
 
 
@@ -31,7 +33,7 @@ def get_config_as_list(key, default: Optional[List] = []):
 
 
 def get_config_as_int(key, default=None):
-    return int(get_config(key, default))
+    return safe_int(get_config(key, default))
 
 
 def get_config_as_bool(key, default=None):

--- a/nlm_ingestor/ingestor/html_ingestor.py
+++ b/nlm_ingestor/ingestor/html_ingestor.py
@@ -3,7 +3,7 @@ import logging
 from bs4 import BeautifulSoup, UnicodeDammit
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
-from nlm_ingestor.ingestor_utils.utils import sent_tokenize, is_integer
+from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize
 from nlm_ingestor.ingestor import line_parser
 import codecs
 
@@ -209,7 +209,7 @@ class HTMLIngestor:
                             all_th = False
                         if col.get("colspan"):
                             header_group_flag = True
-                        col_spans.append(int(col.get("colspan")) if is_integer(col.get("colspan")) else 1)
+                        col_spans.append(safe_int(col.get("colspan"), 1))
                     empty_cols.append(empty_col)
 
                     if not ''.join(col_text).strip():

--- a/nlm_ingestor/ingestor/line_parser.py
+++ b/nlm_ingestor/ingestor/line_parser.py
@@ -6,7 +6,7 @@ import string
 
 from nltk.corpus import stopwords
 
-from nlm_ingestor.ingestor_utils.utils import is_arabic_number
+from nlm_ingestor.ingestor_utils.utils import is_arabic_number, safe_float
 
 from .patterns import abbreviations
 from .patterns import states
@@ -134,7 +134,7 @@ class Word:
         self.check_date()
         try:
             if n:
-                n = round(float(n))
+                n = round(safe_float(n))
                 if n > 0:
                     digits = int(math.log10(n)) + 1
                 elif n == 0:

--- a/nlm_ingestor/ingestor/processors.py
+++ b/nlm_ingestor/ingestor/processors.py
@@ -7,7 +7,7 @@ from . import formatter
 from . import line_parser
 from . import patterns
 from nlm_ingestor.ingestor_utils import spell_utils
-from nlm_ingestor.ingestor_utils.utils import sent_tokenize
+from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -540,20 +540,20 @@ def check_tr_alignment(prev_line, curr_line):
 
 def check_layout(prev_line, curr_line, prev_above_curr):
     prev_line_width = range(
-        int(prev_line.visual_line.min_x),
-        int(prev_line.visual_line.max_x),
+        safe_int(prev_line.visual_line.min_x),
+        safe_int(prev_line.visual_line.max_x),
     )
 
     # weird edge case
     if not prev_line_width:
         prev_line_width = range(
-            int(prev_line.visual_line.max_x),
-            int(prev_line.visual_line.min_x),
+            safe_int(prev_line.visual_line.max_x),
+            safe_int(prev_line.visual_line.min_x),
         )
 
     curr_line_width = range(
-        int(curr_line.visual_line.min_x),
-        int(curr_line.visual_line.max_x),
+        safe_int(curr_line.visual_line.min_x),
+        safe_int(curr_line.visual_line.max_x),
     )
 
     prev_line_width = set(prev_line_width)

--- a/nlm_ingestor/ingestor/sec_html_ingestor.py
+++ b/nlm_ingestor/ingestor/sec_html_ingestor.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
-from nlm_ingestor.ingestor_utils.utils import sent_tokenize, is_integer
+from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize
 from nlm_ingestor.ingestor import line_parser
 import codecs
 
@@ -170,7 +170,7 @@ class SECDoc:
                             all_th = False
                         if col.get("colspan"):
                             header_group_flag = True
-                        col_spans.append(int(col.get("colspan")) if is_integer(col.get("colspan")) else 1)
+                        col_spans.append(safe_int(col.get("colspan"), 1))
 
                     table_row = {
                         "block_idx": len(self.blocks),

--- a/nlm_ingestor/ingestor/visual_ingestor/indent_parser.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/indent_parser.py
@@ -1,5 +1,5 @@
 from nlm_ingestor.ingestor.visual_ingestor import table_parser
-from nlm_ingestor.ingestor_utils.utils import detect_block_center_aligned
+from nlm_ingestor.ingestor_utils.utils import detect_block_center_aligned, safe_int
 from nlm_ingestor.ingestor import line_parser
 import copy
 import operator
@@ -40,11 +40,12 @@ def get_list_item_sum(number, list_type):
     elif list_type == "integer" or list_type == "integer-dot":
         new_number = ""
         for c in number.split("."):
+            c = c.strip()
             if len(c) == 1:
                 new_number += "0"
             if c.isdigit():
                 new_number += c
-        return int(new_number)
+        return safe_int(new_number)
     elif list_type == "letter":
         return sum(ord(c) for c in number)
     else:

--- a/nlm_ingestor/ingestor/visual_ingestor/order_fixer.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/order_fixer.py
@@ -1,4 +1,5 @@
 from functools import cmp_to_key
+from nlm_ingestor.ingestor_utils.utils import safe_float, safe_int
 import numpy as np
 
 REORDER_DEBUG = False
@@ -445,8 +446,9 @@ class OrderFixer:
             top_diff = cb_1_box[0] - cb_2_box[0]
             left_diff = cb_1_box[1] - cb_2_box[1]
             if self.doc.have_y_overlap(cb_1["blocks"][0], cb_2["blocks"][0]) or \
-                    list(range(max(int(cb_1_blk_box[0]), int(cb_2_blk_box[0])),
-                               min(int(cb_1_blk_box[0] + cb_1_blk_box[4]), int(cb_2_blk_box[0] + cb_2_blk_box[4]))+1)):
+                    list(range(max(safe_int(cb_1_blk_box[0]), safe_int(cb_2_blk_box[0])),
+                               min(int(safe_float(cb_1_blk_box[0]) + safe_float(cb_1_blk_box[4])),
+                                   int(safe_float(cb_2_blk_box[0]) + safe_float(cb_2_blk_box[4])))+1)):
                 return left_diff
             else:
                 return top_diff
@@ -509,9 +511,9 @@ class OrderFixer:
                 top_diff = cb_1_box[0] - cb_2_box[0]
                 left_diff = cb_1_box[1] - cb_2_box[1]
                 # Check whether we have an intersection of y coordinate
-                if list(range(max(int(cb_1_box[0]), int(cb_2_box[0])),
-                              min(int(cb_1_last_box[0] + cb_1_last_box[4]),
-                                  int(cb_2_last_box[0] + cb_2_last_box[4]))+1)):
+                if list(range(max(safe_int(cb_1_box[0]), safe_int(cb_2_box[0])),
+                              min(int(safe_float(cb_1_last_box[0]) + safe_float(cb_1_last_box[4])),
+                                  int(safe_float(cb_2_last_box[0]) + safe_float(cb_2_last_box[4])))+1)):
                     return left_diff
                 else:
                     return top_diff

--- a/nlm_ingestor/ingestor/visual_ingestor/table_parser.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/table_parser.py
@@ -1,4 +1,5 @@
 import copy
+from nlm_ingestor.ingestor_utils.utils import safe_int
 import numpy as np
 from collections import Counter
 
@@ -57,14 +58,14 @@ def get_alignment_count(prev_block, curr_block, force_check_curr_block=False):
                 if abs(alignment_deviation) <= 0.1:
                     center_alignment = True
                     break
-            if len(list(range(max(int(short_pos[1]), int(long_pos[1])),
-                              min(int(short_pos[2]), int(long_pos[2]))+1))) >= len(shorter_line[i]["text"]):
+            if len(list(range(max(safe_int(short_pos[1]), safe_int(long_pos[1])),
+                              min(safe_int(short_pos[2]), safe_int(long_pos[2]))+1))) >= len(shorter_line[i]["text"]):
                 within_bounds = True
                 break
         if left_alignment or right_alignment or center_alignment or within_bounds:
             if left_alignment and j == len(longer_line) - 1:
-                if list(range(max(int(short_pos[1]), int(long_pos[1])),
-                              min(int(short_pos[2]), int(long_pos[2]))+1)):
+                if list(range(max(safe_int(short_pos[1]), safe_int(long_pos[1])),
+                              min(safe_int(short_pos[2]), safe_int(long_pos[2]))+1)):
                     alignment_count = alignment_count + 1
                     alignment_pos.append(j)
             elif within_bounds and prev_block["block_type"] == curr_block["block_type"] == 'table_row':

--- a/nlm_ingestor/ingestor/visual_ingestor/vi_helper_utils.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/vi_helper_utils.py
@@ -1,6 +1,7 @@
 """
 Abode for all Visual Ingestor Helper Utils.
 """
+from nlm_ingestor.ingestor_utils.utils import safe_int
 import numpy as np
 
 
@@ -84,8 +85,8 @@ def find_num_cols(block):
         for col_vl in col_vls:
             col_box = col_vl['box_style']
             curr_box = curr_vl['box_style']
-            if list(range(max(int(col_box[1]), int(curr_box[1])),
-                          min(int(col_box[2]), int(curr_box[2]))+1)):
+            if list(range(max(safe_int(col_box[1]), safe_int(curr_box[1])),
+                          min(safe_int(col_box[2]), safe_int(curr_box[2]))+1)):
                 # We have an intersection point.
                 found_intersection = True
                 break

--- a/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
@@ -13,7 +13,7 @@ from itertools import groupby
 from bs4 import BeautifulSoup
 from timeit import default_timer
 
-from nlm_ingestor.ingestor_utils.utils import sent_tokenize
+from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize
 from nlm_ingestor.ingestor_utils.ing_named_tuples import BoxStyle, LineStyle, LocationKey
 from nlm_ingestor.ingestor.visual_ingestor import style_utils, table_parser, indent_parser, block_renderer, order_fixer
 from nlm_ingestor.ingestor import line_parser
@@ -1145,11 +1145,11 @@ class Doc:
                                 buf0_bstyle = group_buf[0]['box_style']
                                 prev_buf_bstyle = group_buf[-1]['box_style']
                                 buf_bstyle = line_info['box_style']
-                                if len(list(range(max(int(buf0_bstyle[1]), int(buf_bstyle[1])),
-                                                  min(int(buf0_bstyle[2]), int(buf_bstyle[2]))+1))) \
-                                        >= 0.4 * (int(buf_bstyle[2]) - int(buf_bstyle[1])) and \
-                                        list(range(max(int(buf0_bstyle[1]), int(prev_buf_bstyle[1])),
-                                                   min(int(buf0_bstyle[2]), int(prev_buf_bstyle[2]))+1)):
+                                if len(list(range(max(safe_int(buf0_bstyle[1]), safe_int(buf_bstyle[1])),
+                                                  min(safe_int(buf0_bstyle[2]), safe_int(buf_bstyle[2]))+1))) \
+                                        >= 0.4 * (safe_int(buf_bstyle[2]) - safe_int(buf_bstyle[1])) and \
+                                        list(range(max(safe_int(buf0_bstyle[1]), safe_int(prev_buf_bstyle[1])),
+                                                   min(safe_int(buf0_bstyle[2]), safe_int(prev_buf_bstyle[2]))+1)):
                                     # Mark as not a table_row if the first VL is more than
                                     # 40% the length of the current VL
                                     is_table_row = False
@@ -1268,8 +1268,8 @@ class Doc:
                         same_top = vhu.compare_top(line_info, vl) or (
                                 (vl['box_style'][4] <= line_info['box_style'][4]) and
                                 ((line_info["space"] >= 0 and
-                                  len(list(range(max(int(vl['box_style'][1]), int(line_info['box_style'][1])),
-                                                 min(int(vl['box_style'][2]), int(line_info['box_style'][2]))+1))) > 0)
+                                  len(list(range(max(safe_int(vl['box_style'][1]), safe_int(line_info['box_style'][1])),
+                                                 min(safe_int(vl['box_style'][2]), safe_int(line_info['box_style'][2]))+1))) > 0)
                                  or
                                  (line_info["space"] < 0 and block_buf[0]['box_style'][2] < line_info['box_style'][1]))
                         )
@@ -1873,8 +1873,8 @@ class Doc:
                         len(gap_bw_vls) > 0 and \
                         vl['box_style'][0] <= (prev_vl['box_style'][0] + (2 * prev_vl['box_style'][4])) and \
                         vl['text'].strip() not in ['$', '€', '£'] and \
-                        len(list(range(max(int(prev_vl['box_style'][1]), int(vl['box_style'][1])),
-                                       min(int(prev_vl['box_style'][2]), int(vl['box_style'][2]))+1))):
+                        len(list(range(max(safe_int(prev_vl['box_style'][1]), safe_int(vl['box_style'][1])),
+                                       min(safe_int(prev_vl['box_style'][2]), safe_int(vl['box_style'][2]))+1))):
                     should_merge = True
             if should_merge:
                 # print("merging: ", prev_vl["text"][0:80], "->", vl["text"][0:80], gap, normal_gap, is_justified, avg_merge_gap)
@@ -2388,8 +2388,8 @@ class Doc:
                     prev_box = left_most_vl['box_style']
                     curr_box = block_vl['box_style']
                     block_box = block['box_style']
-                    intersection_points = list(range(max(int(prev_box[1]), int(curr_box[1])),
-                                                     min(int(prev_box[2]), int(curr_box[2]))+1))
+                    intersection_points = list(range(max(safe_int(prev_box[1]), safe_int(curr_box[1])),
+                                                     min(safe_int(prev_box[2]), safe_int(curr_box[2]))+1))
 
                     if (intersection_points and not block_vl["line_style"] == left_most_vl["line_style"]) or \
                             block_box[1] < min_left or curr_box[3] > 0.6 * self.page_width or \
@@ -3397,8 +3397,8 @@ class Doc:
         line_text = only_text_pattern.sub("", line_text)  # re.sub(r"[^a-zA-Z]+", "", line_text)
         line_text = roman_only_pattern.sub("", line_text)
         return LocationKey(
-            int(box_style[0]),
-            int(box_style[1]),
+            safe_int(box_style[0]),
+            safe_int(box_style[1]),
             line_text
         )
 

--- a/nlm_ingestor/ingestor_utils/parsing_utils.py
+++ b/nlm_ingestor/ingestor_utils/parsing_utils.py
@@ -1,5 +1,6 @@
 from collections import Counter
 import nlm_ingestor.ingestor.visual_ingestor
+from nlm_ingestor.ingestor_utils.utils import safe_int
 
 """
 Contains utility functions for comparing and reconstructing
@@ -46,8 +47,8 @@ def calculate_discrete_overlap(p1, p2, small=True):
     larger or smaller span for
     computing overlap
     """
-    p1 = set(range(int(p1[0]), int(p1[1])))
-    p2 = range(int(p2[0]), int(p2[1]))
+    p1 = set(range(safe_int(p1[0]), safe_int(p1[1])))
+    p2 = range(safe_int(p2[0]), safe_int(p2[1]))
     if len(p1) > len(p2):
         if small:
             denominator = len(p2)

--- a/nlm_ingestor/ingestor_utils/utils.py
+++ b/nlm_ingestor/ingestor_utils/utils.py
@@ -547,8 +547,25 @@ def normalize_kangxi_radicals(text: str) -> str:
     return text
 
 
-def is_integer(text: str | None) -> bool:
+def safe_int(value, fallback = 0) -> int:
     """
-    Check if all the characters in the text are integers.
+    Parse the integer from the value.
     """
-    return bool(re.fullmatch(r'\d+', text or ''))
+    try:
+        if isinstance(value, str):
+            value = value.strip()
+        return int(value)
+    except (ValueError, TypeError):
+        return fallback
+
+
+def safe_float(value, fallback = 0.0) -> float:
+    """
+    Parse the float from the value.
+    """
+    try:
+        if isinstance(value, str):
+            value = value.strip()
+        return float(value)
+    except (ValueError, TypeError):
+        return fallback

--- a/tests/run_ingestor_page_test.py
+++ b/tests/run_ingestor_page_test.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 from itertools import groupby
 
 from bs4 import BeautifulSoup
+from nlm_ingestor.ingestor_utils.utils import safe_int
 from nlm_utils.storage import file_storage
 from pymongo import MongoClient
 from tika import parser
@@ -102,7 +103,7 @@ def compare_results(test, html_text):
             continue
         style = tag.get("style")
         if style and "margin-left: " in style and "px" in style:
-            indent = int(style.split("margin-left: ")[1].split("px")[0]) + 20
+            indent = safe_int(style.split("margin-left: ")[1].split("px")[0]) + 20
         elif not style and (tag.get("block_idx") or tag.get("block_idx") == "0"):
             indent = 20
         else:
@@ -270,7 +271,7 @@ if __name__ == "__main__":
     if args.doc_type:
         doc_type = args.doc_type
     if args.num_procs:
-        num_procs = int(args.num_procs)
+        num_procs = safe_int(args.num_procs)
     print(f"running script with -> docId: {doc_id_list}, docType: {doc_type}, num_procs: {num_procs}")
     if len(doc_id_list) > 0:
         for doc_id in doc_id_list:

--- a/tests/run_ingestor_table_tests.py
+++ b/tests/run_ingestor_table_tests.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 from itertools import groupby
 
 from bs4 import BeautifulSoup
+from nlm_ingestor.ingestor_utils.utils import safe_int
 from nlm_utils.storage import file_storage
 from pymongo import MongoClient
 from tika import parser
@@ -291,7 +292,7 @@ if __name__ == "__main__":
     if args.doc_type:
         doc_type = args.doc_type
     if args.num_procs:
-        num_procs = int(args.num_procs)
+        num_procs = safe_int(args.num_procs)
     print(f"running script with -> docId: {doc_id_list}, docType: {doc_type}, num_procs: {num_procs}")
     if len(doc_id_list) > 0:
         for doc_id in doc_id_list:

--- a/tests/run_ingestor_test_full_doc.py
+++ b/tests/run_ingestor_test_full_doc.py
@@ -6,6 +6,7 @@ import multiprocessing as mp
 from itertools import groupby
 
 from bs4 import BeautifulSoup
+from nlm_ingestor.ingestor_utils.utils import safe_int
 from nlm_utils.storage import file_storage
 from pymongo import MongoClient
 from tika import parser
@@ -267,7 +268,7 @@ if __name__ == "__main__":
     if args.doc_type:
         doc_type = args.doc_type
     if args.num_procs:
-        num_procs = int(args.num_procs)
+        num_procs = safe_int(args.num_procs)
     print(f"running script with -> docId: {doc_id_list}, docType: {doc_type}, num_procs: {num_procs}")
     if len(doc_id_list) > 0:
         for doc_id in doc_id_list:


### PR DESCRIPTION
## 更新描述

- 问题：get_list_item_sum 中将字符串转为 int 时没有做空判断
- 解决办法：
  - 添加函数 `safe_int(value, fallback)` 和 `safe_float(value, fallback)`，转换失败时返回 fallback 值
    - https://github.com/hongshancapital/nlm-ingestor/pull/12/files#diff-6a0ff7420ba650416c6240b830238a3d6160718a3cad3888a8a3b21a084d2b05
      ![screenshot-2024-09-24 16 58 17](https://github.com/user-attachments/assets/32f4a8f6-3e30-49e5-82ea-072ee0d9ba48)
  - 将项目中使用 `int(value)` 和 `float(value)` 转换类型且参数可能不为有效值的地方替换为 `safe_int(value, fallback)` 和 `safe_float(value, fallback)`

<img width="299" alt="screenshot-2024-09-24 14 25 26" src="https://github.com/user-attachments/assets/0c12433c-097a-45e7-b4ef-0b26f2f45623">

## 各种类型文件解析测试

![screenshot-2024-09-24 16 48 30](https://github.com/user-attachments/assets/1c606b67-9099-4b16-9254-34486b1d3816)
![screenshot-2024-09-24 16 49 20](https://github.com/user-attachments/assets/f35c955f-25d6-4a6b-9637-f37da6afad28)
![screenshot-2024-09-24 16 49 45](https://github.com/user-attachments/assets/50926b85-6a30-49b0-b26b-c3c14dd5c5f5)
![screenshot-2024-09-24 16 50 00](https://github.com/user-attachments/assets/2adb7c45-bc44-41bd-bbd4-101513b1e4e6)
![screenshot-2024-09-24 16 50 18](https://github.com/user-attachments/assets/eb70a37f-bc88-4949-b581-80e68719ebdf)
![screenshot-2024-09-24 16 50 40](https://github.com/user-attachments/assets/671dbaa9-4124-4f15-8f54-4c6833f4b1e2)
![screenshot-2024-09-24 16 50 58](https://github.com/user-attachments/assets/22706a1f-4796-4a06-bd2b-5ef0741ef6fc)
![screenshot-2024-09-24 16 51 17](https://github.com/user-attachments/assets/5213d066-679b-4a86-a562-59362778047e)
