### PR TITLE
Fix "pop from empty list"

### DIFF
--- a/nlm_ingestor/ingestor/table_builder.py
+++ b/nlm_ingestor/ingestor/table_builder.py
@@ -106,7 +106,7 @@ def get_row(row):
         colon_rule = word[-1] == ":"
         if word == "of" and len(row_list) and prev_type != "str":
             str_buff += row_list.pop()
-            unit_list.pop()
+            unit_list.pop() if unit_list else None
 
         if numeric.search(word) is not None:
             if prev_type == "str":

--- a/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
@@ -2068,8 +2068,8 @@ class Doc:
                     reprocess_num = 1
                     if included_prev_2_prev_blk:
                         reprocess_num = 2
-                        organized_blocks.pop()
-                    organized_blocks.pop()  # replace previous single block with combo
+                        organized_blocks.pop() if organized_blocks else None
+                    organized_blocks.pop() if organized_blocks else None  # replace previous single block with combo
                     idx = idx - 1  # reprocess the current block
                     block_idx = block_idx - reprocess_num
                     block = new_block
@@ -2753,8 +2753,8 @@ class Doc:
                     block["block_type"] = "header"
                     block["header_type"] = "parenthesized_hdr"
                 curr_block = block
-                block = organized_blocks.pop()
-                if block["block_type"] != "table_row" and curr_block["block_type"] != "table_row":
+                block = organized_blocks.pop() if organized_blocks else None
+                if block and block["block_type"] != "table_row" and curr_block["block_type"] != "table_row":
                     # Change the block_class and block_idx
                     block["block_class"], curr_block["block_class"] = curr_block["block_class"], block["block_class"]
                     block["block_idx"], curr_block["block_idx"] = curr_block["block_idx"], block["block_idx"]
@@ -2785,7 +2785,7 @@ class Doc:
                 print("merging last block", new_block["block_text"], new_block["block_type"])
             if new_block["block_type"] == "list_item":
                 new_block["list_type"] = Doc.get_list_item_subtype(new_block)
-            organized_blocks.pop()  # replace previous single block with combo
+            organized_blocks.pop() if organized_blocks else None  # replace previous single block with combo
             organized_blocks.append(new_block)
 
         if table_start_idx != table_end_idx and table_start_idx < len(organized_blocks):


### PR DESCRIPTION
## Description of the change

- 生产环境发生 `pop from empty list` 异常
  - [Sentry](https://hongshan.sentry.io/issues/5866972648/?alert_rule_id=14678761&alert_type=issue&environment=dev&notification_uuid=1436e1eb-efe9-4f74-b759-199cec9438ff&project=6073770&referrer=slack)
  - 原因：调用 `organized_blocks` 的 `pop()` 前没有检查 list 是否为空
  - 解决办法：调用 list 的 `pop()` 前判断 list 是否为空，若为空则不执行 `pop()`

## Test

### Docker build 成功，解析成功

<img width="1063" alt="screenshot-2025-04-07 12 21 08" src="https://github.com/user-attachments/assets/9f2047b6-b0fb-4b9e-85ce-f0078252dd85" />
<img width="1060" alt="screenshot-2025-04-07 12 41 05" src="https://github.com/user-attachments/assets/8a4264a4-cd3b-447a-b04e-32b08c633ee9" />

- 在修改的地方打印日志，未见异常
  <img width="365" alt="screenshot-2025-04-07 13 31 34" src="https://github.com/user-attachments/assets/8380f69b-f92d-4dbe-b162-2be3725f2a60" />

