### PR TITLE
fix "NoneType is not subscriptable"

### DIFF
--- a/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
@@ -2765,15 +2765,16 @@ class Doc:
                             vhu.find_num_cols(curr_block)[0] > vhu.find_num_cols(table_row_with_max_cols)[0]:
                         table_row_with_max_cols = curr_block
                 organized_blocks.append(curr_block)
-            if block["block_type"] == "table_row":
-                if not table_row_with_max_cols or \
-                        vhu.find_num_cols(block)[0] > vhu.find_num_cols(table_row_with_max_cols)[0]:
-                    table_row_with_max_cols = block
-            organized_blocks.append(block)
+            if block:
+                if block["block_type"] == "table_row":
+                    if not table_row_with_max_cols or \
+                            vhu.find_num_cols(block)[0] > vhu.find_num_cols(table_row_with_max_cols)[0]:
+                        table_row_with_max_cols = block
+                organized_blocks.append(block)
+                block["block_idx"] = block_idx
+                prev_block = block
             idx = idx + 1
-            block["block_idx"] = block_idx
             block_idx = block_idx + 1
-            prev_block = block
 
         if len(block_buf) > 0:
             if prev_block:


### PR DESCRIPTION
## Description

- 解决 "NoneType is not subscriptable" 问题
  - 原因：block 被重新赋值后可能会变成 None，此时不能继续对其操作
    <img width="721" alt="screenshot-2025-05-08 18 39 44" src="https://github.com/user-attachments/assets/36cc5ed4-8845-4742-8868-8be253c6be1f" />
  - 解决办法：增加 block 是否为 None 的判断

## Test

- 能够正常解析 PDF（⚠️ 未再现问题）
  <img width="1345" alt="screenshot-2025-05-08 18 51 30" src="https://github.com/user-attachments/assets/6c4989c0-6b78-4506-a09a-ac3f57deb1d2" />
  <img width="1345" alt="screenshot-2025-05-08 18 54 54" src="https://github.com/user-attachments/assets/cfda2a9d-2280-4c81-96ef-223ee9e21992" />
  <img width="856" alt="screenshot-2025-05-08 18 55 04" src="https://github.com/user-attachments/assets/f5a03977-77d5-4d88-a271-b500f199ac2d" />
  <img width="1343" alt="screenshot-2025-05-08 18 56 21" src="https://github.com/user-attachments/assets/d4c40fc0-b722-4391-bb2b-6b1a5825d7fe" />
  <img width="821" alt="screenshot-2025-05-08 18 56 30" src="https://github.com/user-attachments/assets/f8da5eb2-74c2-4ad8-bfec-007f2c9f3c37" />
