### PR TITLE
fix: unsanitized dynamic input in file path

### DIFF
--- a/nlm_ingestor/file_parser/markdown_parser.py
+++ b/nlm_ingestor/file_parser/markdown_parser.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 import mistune
-from nlm_ingestor.ingestor_utils.utils import sent_tokenize
+from nlm_ingestor.ingestor_utils.utils import sent_tokenize, safe_open
 
 import nlm_ingestor.ingestion_daemon.config as cfg
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
@@ -164,7 +164,7 @@ class MarkdownDocument:
         self.logger = logging.getLogger(self.__class__.__name__)
         self.logger.setLevel(logging.INFO)
         markdown_text = ""
-        with open(doc_location) as file:
+        with safe_open(doc_location) as file:
             markdown_text = file.read()
         self.blocks, self.html_str = parse_markdown_to_blocks(markdown_text)
         for block in self.blocks:

--- a/nlm_ingestor/file_parser/tika_parser.py
+++ b/nlm_ingestor/file_parser/tika_parser.py
@@ -6,6 +6,7 @@ from tika import parser
 
 from nlm_ingestor.file_parser.file_parser import FileParser
 from nlm_utils.utils.utils import ensure_bool
+from nlm_ingestor.ingestor_utils.utils import safe_open
 
 
 class TikaFileParser(FileParser):
@@ -36,20 +37,20 @@ class TikaFileParser(FileParser):
 
     def parse_to_clean_html(self, filepath):
         if not find_tika_header(filepath):
-            with open(filepath) as file:
+            with safe_open(filepath) as file:
                 file_data = BeautifulSoup(
                     file.read(), features="html.parser",
                 ).prettify()
             return parser.from_buffer(file_data, xmlContent=True)
         else:
-            with open(filepath) as file:
+            with safe_open(filepath) as file:
                 file_data = file.read()
             return {"metadata": "", "content": file_data, "status": ""}
 
 
 def find_tika_header(fp):
     try:
-        with open(fp) as file:
+        with safe_open(fp) as file:
             file_data = file.read()
             soup = BeautifulSoup(file_data, "html.parser")
             # print(str(soup.find_all('head')[0]))

--- a/nlm_ingestor/ingestion_daemon/__main__.py
+++ b/nlm_ingestor/ingestion_daemon/__main__.py
@@ -9,7 +9,7 @@ from nlm_ingestor.ingestor import ingestor_api
 from nlm_utils.utils import file_utils
 import boto3
 
-from nlm_ingestor.ingestor_utils.utils import normalize_kangxi_radicals
+from nlm_ingestor.ingestor_utils.utils import normalize_kangxi_radicals, safe_unlink
 
 app = Flask(__name__)
 
@@ -91,7 +91,7 @@ def parse_document(
             ]
 
         if tmp_file and os.path.exists(tmp_file):
-            os.unlink(tmp_file)
+            safe_unlink(tmp_file)
         return make_response(
             jsonify({"status": 200, "return_dict": return_dict}),
         )
@@ -106,7 +106,7 @@ def parse_document(
 
     finally:
         if tmp_file and os.path.exists(tmp_file):
-            os.unlink(tmp_file)
+            safe_unlink(tmp_file)
     return make_response(jsonify({"status": status, "reason": msg}), rc)
 
 

--- a/nlm_ingestor/ingestor/html_ingestor.py
+++ b/nlm_ingestor/ingestor/html_ingestor.py
@@ -3,7 +3,7 @@ import logging
 from bs4 import BeautifulSoup, UnicodeDammit
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
-from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize
+from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize, safe_open
 from nlm_ingestor.ingestor import line_parser
 import codecs
 
@@ -16,11 +16,11 @@ class HTMLIngestor:
         if str(type(file_name)) == "<class 'bs4.element.Tag'>":
             self.html = file_name
         else:
-            with open(file_name, 'rb') as f:
+            with safe_open(file_name, 'rb') as f:
                 raw_data = f.read()
                 suggestion = UnicodeDammit(raw_data)
-            f = codecs.open(file_name, 'r', encoding=suggestion.original_encoding, errors='ignore')
-            self.html = BeautifulSoup(f.read(), features="html5lib")
+            with safe_open(file_name, 'r', encoding=suggestion.original_encoding, errors='ignore') as f:
+                self.html = BeautifulSoup(f.read(), features="html5lib")
             self.html = self.html.find("body")
         self.sec = sec
         self.blocks = []

--- a/nlm_ingestor/ingestor/ingestor_api.py
+++ b/nlm_ingestor/ingestor/ingestor_api.py
@@ -10,7 +10,7 @@ from timeit import default_timer
 
 import nlm_ingestor.ingestion_daemon.config as cfg
 from nlm_ingestor.file_parser import markdown_parser
-from nlm_ingestor.ingestor_utils.utils import NpEncoder
+from nlm_ingestor.ingestor_utils.utils import NpEncoder, safe_open, safe_unlink
 from nlm_ingestor.ingestor import html_ingestor, pdf_ingestor, xml_ingestor, text_ingestor
 from nlm_ingestor.file_parser import pdf_file_parser
 from nlm_utils.utils import ensure_bool
@@ -68,7 +68,7 @@ def ingest_document(
         else: # use tika parser as a catch all
             logger.info(f"defaulting to tika parser for mime_type {mime_type}")
             parsed_content = pdf_file_parser.parse_to_html(doc_location)
-            with open(doc_location, "w") as file:
+            with safe_open(doc_location, "w") as file:
                 file.write(parsed_content["content"])
             ingestor = html_ingestor.HTMLIngestor(doc_location)
             return_dict = {
@@ -76,7 +76,7 @@ def ingest_document(
             }
 
         if doc_location and os.path.exists(doc_location):
-            os.unlink(doc_location)
+            safe_unlink(doc_location)
             logger.info(f"File {doc_location} deleted")
         return return_dict, ingestor
 

--- a/nlm_ingestor/ingestor/sec_html_ingestor.py
+++ b/nlm_ingestor/ingestor/sec_html_ingestor.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
-from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize
+from nlm_ingestor.ingestor_utils.utils import safe_int, sent_tokenize, safe_open
 from nlm_ingestor.ingestor import line_parser
 import codecs
 
@@ -12,9 +12,9 @@ class SECDoc:
             self.html = file_name
         else:
             # f = codecs.open(file_name, 'r')
-            f = open(file_name, 'r')
-            # self.html = BeautifulSoup(f.read(), features="lxml")
-            self.html = BeautifulSoup(f.read(), 'html.parser')
+            with safe_open(file_name, 'r') as f:
+                # self.html = BeautifulSoup(f.read(), features="lxml")
+                self.html = BeautifulSoup(f.read(), 'html.parser')
             self.html = self.html.find("body").find()
         self.sec = sec
         self.blocks = []

--- a/nlm_ingestor/ingestor/text_ingestor.py
+++ b/nlm_ingestor/ingestor/text_ingestor.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections import namedtuple
-from nlm_ingestor.ingestor_utils.utils import NpEncoder
+from nlm_ingestor.ingestor_utils.utils import NpEncoder, safe_open
 from nlm_ingestor.ingestor_utils import utils
 from nlm_ingestor.ingestor.visual_ingestor import block_renderer
 from nlm_ingestor.ingestor_utils.ing_named_tuples import LineStyle
@@ -14,7 +14,7 @@ class TextIngestor:
         render_format = parse_options.get("render_format", "all") \
             if parse_options else "all"
        
-        with open(doc_location) as f:
+        with safe_open(doc_location) as f:
             raw_lines = f.readlines()
 
         blocks, _block_texts, _sents, _file_data, result, page_dim, num_pages = parse_blocks(

--- a/nlm_ingestor/ingestor_utils/ner_dict.py
+++ b/nlm_ingestor/ingestor_utils/ner_dict.py
@@ -4,6 +4,7 @@ import re
 from string import punctuation
 from typing import List, Dict
 from unidecode import unidecode
+from nlm_ingestor.ingestor_utils.utils import safe_open
 
 STOPWORDS_GENE = [
     'a',
@@ -181,11 +182,11 @@ class NERDict:
         return self.ner_dict
 
     def load_ner_dict_from_json(self, json_file: str):
-        with open(json_file) as read_file:
+        with safe_open(json_file) as read_file:
             self.ner_dict = json.load(read_file)
 
     def save_ner_dict_to_json(self, json_file: str):
-        with open(json_file, 'w') as write_file:
+        with safe_open(json_file, 'w') as write_file:
             json.dump(self.ner_dict, write_file, indent=2)
 
     def find_keys_in_text(self, text: str, stop_words: List[str]):

--- a/nlm_ingestor/ingestor_utils/word_splitter.py
+++ b/nlm_ingestor/ingestor_utils/word_splitter.py
@@ -3,6 +3,7 @@ import re
 from math import log
 
 import nlm_ingestor.ingestor as ingestor
+from nlm_ingestor.ingestor_utils.utils import safe_open
 
 word_file = os.path.join(
     os.path.dirname(os.path.abspath(ingestor.__file__)), "../ingestor_utils/words.txt",
@@ -12,7 +13,7 @@ word_file = os.path.join(
 class WordSplitter:
     def __init__(self, word_file=word_file):
         # Build a cost dictionary, assuming Zipf's law and cost = -math.log(probability).
-        with open(word_file) as f:
+        with safe_open(word_file) as f:
             words = f.read().split()
             self._word2cost = {
                 k: log((i + 1) * log(len(words))) for i, k in enumerate(words)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gunicorn==22.0.0
 werkzeug==3.0.6
 tika==2.6.0
 bs4==0.0.2
-nltk==3.9
+nltk==3.6.2
 python-magic==0.4.22
 numpy==1.24.4
 tqdm==4.66.3

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "werkzeug==3.0.6",
         "tika==2.6.0",
         "bs4==0.0.2",
-        "nltk==3.9",
+        "nltk==3.6.2",
         "python-magic==0.4.22",
         "numpy==1.24.4",
         "tqdm==4.66.3",


### PR DESCRIPTION
## Description

- 修复 Unsanitized dynamic input in file path 风险
  <img width="1569" height="866" alt="screenshot-2025-10-29 15 33 53" src="https://github.com/user-attachments/assets/1f568f01-40ae-4ccc-9562-55cd1ddbce97" />
  - 风险描述：
    > Using unsanitized dynamic input to determine file paths can allow attackers to gain access to files and folders outside of the intended scope. This vulnerability occurs when input provided by users is directly used to access the filesystem without proper validation or sanitization.
  - 当前代码对 `open` 和 `os.unlink` 的使用情况
    <img width="805" height="422" alt="screenshot-2025-10-29 14 59 11" src="https://github.com/user-attachments/assets/0a294868-89ea-4e74-a150-860f59023e50" />
    - **结论：当前代码实际无风险，文件路径要么是临时文件的路径，要么是项目路径下的 `nlm_ingestor/ingestor_utils/words.txt`**
  - 解决办法：对于所有 `open` 和 `os.unlink`，封装相应的函数，检查路径是否在系统临时文件路径或项目路径下，如果不在系统临时文件路径或项目路径下则报错
- 降级 `nltk` 到 `3.6.2`，因为 `nlm-utils 0.1.2` 不兼容更高版本

## Test

<img width="1522" height="959" alt="screenshot-2025-10-29 16 10 56" src="https://github.com/user-attachments/assets/40c97344-d411-4190-b205-c4720ec650c8" />
<img width="1518" height="963" alt="screenshot-2025-10-29 16 12 16" src="https://github.com/user-attachments/assets/2d2497c0-ab5c-47de-b7b5-1a5503124feb" />
<img width="1517" height="957" alt="screenshot-2025-10-29 16 12 53" src="https://github.com/user-attachments/assets/2e4b8c99-02f6-408e-bab4-c7d8b7ed8570" />
<img width="1519" height="728" alt="screenshot-2025-10-29 16 14 42" src="https://github.com/user-attachments/assets/d4303aeb-b315-4a5c-849e-83be9228bcb6" />
