### PR TITLE
Fix division by zero issues

### DIFF
--- a/nlm_ingestor/ingestor/line_parser.py
+++ b/nlm_ingestor/ingestor/line_parser.py
@@ -641,7 +641,7 @@ class Line:
 
         self.continuing_line = self.has_continuing_chars and not self.separate_line
 
-        self.has_spaced_characters = single_letter_word_count / self.word_count > 0.8
+        self.has_spaced_characters = self.word_count > 0 and single_letter_word_count / self.word_count > 0.8
 
         self.set_line_type()
 

--- a/nlm_ingestor/ingestor/pdf_ingestor.py
+++ b/nlm_ingestor/ingestor/pdf_ingestor.py
@@ -76,12 +76,6 @@ def parse_pdf(doc_location, parse_options):
             p_per_page.append(len(page.find_all("p")))
         p_per_page = np.array(p_per_page)
         sparse_page_count = np.count_nonzero(p_per_page < 4)
-        if apply_ocr:
-            # even if ocr is enabled, we don't want to run it if the document is not sparse
-            needs_ocr = sparse_page_count / len(pages) > 0.3
-            if needs_ocr:
-                logger.info(
-                    f"Running PDF OCR: sparse_page_count: {sparse_page_count}, n_pages: {len(pages)}")
 
     else:
         wall_time = default_timer() * 1000

--- a/nlm_ingestor/ingestor/processors.py
+++ b/nlm_ingestor/ingestor/processors.py
@@ -443,6 +443,9 @@ def visual_header_check(prev_line, curr_line, same_font):
 
 
 def visual_header_from_stats(prev_line, curr_line, page_stats):
+    if not page_stats["fs_list"]:
+        return False
+
     prev_fs = prev_line.visual_line.fs
     curr_fs = curr_line.visual_line.fs
 

--- a/nlm_ingestor/ingestor/styling_utils.py
+++ b/nlm_ingestor/ingestor/styling_utils.py
@@ -586,7 +586,7 @@ def p_to_lines(p_items: list) -> list:
                     continue
             vertical_stack_count = 1
             # previous p_tag and current p_tag are likely on different lines
-            has_many_numbers = (
+            has_many_numbers = len(line_info["text_list"]) > 0 and (
                 sum(
                     [
                         1 if re.sub(r"[\$\%\,\.\-\']", "", word).isdigit() else 0

--- a/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
+++ b/nlm_ingestor/ingestor/visual_ingestor/visual_ingestor.py
@@ -2491,9 +2491,9 @@ class Doc:
                 curr_top = block['box_style'][0]
                 prev_bottom = prev_top + prev_block['box_style'][4]
                 curr_bottom = curr_top + block['box_style'][4]
-                bottom_space = (curr_bottom - prev_bottom)/block['box_style'][4]
+                bottom_space = (curr_bottom - prev_bottom)/block['box_style'][4] if block['box_style'][4] else 0
                 top_diff = curr_top - prev_top
-                top_space = top_diff / prev_block['box_style'][4]
+                top_space = top_diff / prev_block['box_style'][4] if prev_block['box_style'][4] else 0
                 # print("...block::", block["block_text"][0:80])
                 # space_between_blocks = bottom_space
                 too_much_space = bottom_space > table_end_space_threshold and top_space > table_end_space_threshold
@@ -2586,6 +2586,7 @@ class Doc:
                                     # the previous row
                                     alignment_break = False
                                 elif alignment_break and \
+                                        len(block["visual_lines"]) > 0 and \
                                         align_count/len(block["visual_lines"]) >= align_threshold and \
                                         0 < block_idx - prev_table_row["block_idx"] < 3:
                                     # If most of the visual lines align and if the previous table row is within 3 blocks
@@ -3222,7 +3223,7 @@ class Doc:
                 # print(organized_blocks[row_idx]["block_text"])
                 align_count, prev_count, align_pos = table_parser.get_alignment_count(prev_block,
                                                                                       organized_blocks[row_idx])
-                if align_count / prev_count > 0.5 and len(set(align_pos)) > 1:
+                if prev_count > 0 and align_count / prev_count > 0.5 and len(set(align_pos)) > 1:
                     is_aligned = True
                     break
             if ((same_class or (is_aligned and
@@ -4228,9 +4229,10 @@ class Doc:
                 name_decider = False
                 if json_rec['noun_chunks']:
                     noun_chunk_str = " ".join(json_rec['noun_chunks'])
+                    effective_word_count = json_rec['word_count'] - json_rec['stop_word_count']
                     if translated_str == noun_chunk_str or \
-                            (len(noun_chunk_str.split()) /
-                             (json_rec['word_count'] - json_rec['stop_word_count'])) > 0.75:
+                            (effective_word_count > 0 and
+                             len(noun_chunk_str.split()) / effective_word_count > 0.75):
                         name_decider = True
                 if not name_decider:
                     merged_text = temp_blocks[-1]["block_text"]


### PR DESCRIPTION
## Description of the change

| 文件 | 原因 | 修改方式 |
|------|------|----------|
| `line_parser.py:644` | `self.word_count` 为 0 时除法触发 ZeroDivisionError | 除法前加 `self.word_count > 0` 短路保护 |
| `pdf_ingestor.py:79-84` | `sparse_page_count / len(pages)` 可能除零，且结果 `needs_ocr` 未被使用 | 直接删除无效代码块 |
| `processors.py:446-447` | `page_stats["fs_list"]` 为空列表时后续取值会异常 | 函数入口增加空列表守卫，提前返回 `False` |
| `styling_utils.py:589` | `line_info["text_list"]` 为空时 `len()` 为 0 触发 ZeroDivisionError | 除法前加 `len(...) > 0` 短路保护 |
| `visual_ingestor.py:2494,2496` | `box_style[4]`（元素高度）为 0 时触发 ZeroDivisionError | 行内 `if x else 0` 零值保护 |
| `visual_ingestor.py:2589` | `block["visual_lines"]` 为空时 `align_count/len(...)` 除零 | 条件链中增加 `len(...) > 0` 前置检查 |
| `visual_ingestor.py:3225` | `prev_count` 为 0 时 `align_count / prev_count` 除零 | 除法前加 `prev_count > 0` 短路保护 |
| `visual_ingestor.py:4231-4234` | `word_count - stop_word_count` 为 0 时除零 | 提取为 `effective_word_count` 变量并加 `> 0` 检查 |
